### PR TITLE
Change user/group to nobody:nogroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.18.0
+
+* Run as user `nobody` and group `nogroup` instead of `root`.
+
 ## 1.17.7
 
 * Upgrade to nginx 1.17.7.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM nginx:1.17.7-alpine
 
 STOPSIGNAL SIGQUIT
+
+USER nobody:nogroup


### PR DESCRIPTION
Because we don't need to run as `root`. To note the UID of `nobody` is `65534` and the GID of `nogroup` is `65533`. The `nginx:1.17-alpine` image already has a `nobody` user and `nobody`/`nogroup` groups. See below:

```console
$ docker run -it nginx:1.17-alpine /bin/sh
/ # awk -F: '{printf "%s:%s\n",$1,$3}' /etc/passwd
root:0
bin:1
daemon:2
adm:3
lp:4
sync:5
shutdown:6
halt:7
mail:8
news:9
uucp:10
operator:11
man:13
postmaster:14
cron:16
ftp:21
sshd:22
at:25
squid:31
xfs:33
games:35
postgres:70
cyrus:85
vpopmail:89
ntp:123
smmsp:209
guest:405
nobody:65534
nginx:101

/ # cat /etc/group
root:x:0:root
bin:x:1:root,bin,daemon
daemon:x:2:root,bin,daemon
sys:x:3:root,bin,adm
adm:x:4:root,adm,daemon
tty:x:5:
disk:x:6:root,adm
lp:x:7:lp
mem:x:8:
kmem:x:9:
wheel:x:10:root
floppy:x:11:root
mail:x:12:mail
news:x:13:news
uucp:x:14:uucp
man:x:15:man
cron:x:16:cron
console:x:17:
audio:x:18:
cdrom:x:19:
dialout:x:20:root
ftp:x:21:
sshd:x:22:
input:x:23:
at:x:25:at
tape:x:26:root
video:x:27:root
netdev:x:28:
readproc:x:30:
squid:x:31:squid
xfs:x:33:xfs
kvm:x:34:kvm
games:x:35:
shadow:x:42:
postgres:x:70:
cdrw:x:80:
usb:x:85:
vpopmail:x:89:
users:x:100:games
ntp:x:123:
nofiles:x:200:
smmsp:x:209:smmsp
locate:x:245:
abuild:x:300:
utmp:x:406:
ping:x:999:
nogroup:x:65533:
nobody:x:65534:
nginx:x:101:nginx
www-data:x:82:
```