### PR TITLE
Change group to nobody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.18.0
+## 1.17.7-1
 
 * Run as user `nobody` and group `nobody` instead of `root`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.18.0
 
-* Run as user `nobody` and group `nogroup` instead of `root`.
+* Run as user `nobody` and group `nobody` instead of `root`.
 
 ## 1.17.7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM nginx:1.17.7-alpine
 
 STOPSIGNAL SIGQUIT
 
-USER nobody:nogroup
+USER nobody:nobody


### PR DESCRIPTION
Continuation of https://github.com/Intellection/docker-nginx/pull/3 to fix the user/group to nobody: nobody so that the UID & GID are both 65534.