### PR TITLE
Upgrade nginx to v1.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## 1.25.2
+
+* Upgrade to Nginx 1.25.2.
+* Upgrade to Alpine 3.18.
+
 ## 1.23.3
 
-* Upgrade to nginx 1.23.3.
+* Upgrade to Nginx 1.23.3.
 
 ## 1.19.5
 
-* Upgrade to nginx 1.19.5.
+* Upgrade to Nginx 1.19.5.
 
 ## 1.17.7-3
 
@@ -25,9 +30,9 @@
 
 ## 1.17.7
 
-* Upgrade to nginx 1.17.7.
+* Upgrade to Nginx 1.17.7.
 
 ## 1.16.1
 
-* Use nginx 1.16.1 alpine as upstream base image.
+* Use Nginx 1.16.1 alpine as upstream base image.
 * Change `STOPSIGNAL` to `SIGQUIT`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.23.3-alpine
+FROM nginx:1.25.2-alpine
 
 ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
 


### PR DESCRIPTION
### Overview

Upgrades Nginx to v1.25.2, which transitively also upgrades from [Alpine v3.17 to v3.18](https://hub.docker.com/layers/library/nginx/1.25.2-alpine/images/sha256-34b58b4f5c6d133d97298cbaae140283dc325ff1aeffb28176f63078baeffd14?context=explore). This should alleviate potential  [DNS issues](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues) that [plagued](https://www.theregister.com/2023/05/16/alpine_linux_318/) Alpine for years.

See [changelog](https://nginx.org/en/CHANGES) for what's changed since v1.19.5.

### References

* https://www.theregister.com/2023/05/16/alpine_linux_318
* https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues
* https://nginx.org/en/CHANGES
