### PR TITLE
Update base image to `nginx:1.25.3-bookworm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.25.3
+
+* Upgrade to Nginx 1.25.3.
+* Switch from Alpine to Debian (Bookworm).
+
 ## 1.25.2
 
 * Upgrade to Nginx 1.25.2.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Intellection/sre
+* @Intellection/SRE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.2-alpine
+FROM nginx:1.25.3-alpine
 
 ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.3-alpine
+FROM nginx:1.25.3-bookworm
 
 ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
 


### PR DESCRIPTION
Updating the version because there's a new version and moving off Alpine because the `single-request-reopen` option we use in `resolve.conf` has no effect on Alpine containers. Their resolver [only supports](https://git.musl-libc.org/cgit/musl/tree/src/network/resolvconf.c#n40) `ndots`, `attempts`, and `timeout`. As much as the DNS issues have been addressed with the upgrade in https://github.com/Intellection/docker-nginx/pull/10, I think we should just move off Alpine and not have to worry about anything.

### References

* https://git.musl-libc.org/cgit/musl/tree/src/network/resolvconf.c#n40
* https://blog.quentin-machu.fr/2018/06/24/5-15s-dns-lookups-on-kubernetes/