### PR TITLE
[SRE-3433] Upgrade nginx to v1.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.25.4
+
+* Upgrade to Nginx 1.25.4.
+
 ## 1.25.3
 
 * Upgrade to Nginx 1.25.3.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.3-bookworm
+FROM nginx:1.25.4-bookworm
 
 ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
 


### PR DESCRIPTION
### Overview

Upgrades Nginx to [v1.25.4](https://github.com/nginx/nginx/releases/tag/release-1.25.4) to side-step the following error when building the [`docker-nginx-proxy`](https://github.com/Intellection/docker-nginx-proxy/) image:

```
nginx: [emerg] module "/etc/nginx/modules/ngx_http_headers_more_filter_module.so" version 1025003 instead of 1025004 in /etc/nginx/nginx.conf:1
```

See [changelog](https://nginx.org/en/CHANGES) for what's changed since v1.25.4.

### References

* https://nginx.org/en/CHANGES
