### PR TITLE
[SRE-4238] Use Github Actions to test and release multi-platform docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: release-docker-image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Version ${{ github.ref }}
+          draft: false
+          prerelease: false
+  docker-hub-release:
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: zappi/nginx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build, tag, and push image to Amazon ECR
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+      - name: Update description on Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: zappi/nginx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: test-docker-image
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: zappi/nginx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Test multi-arch building of image
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
So that we can target `linux/amd64` and `linux/arm64`.

### Checklist

* [x] Delete automated builds on Docker Hub
* [x] Delete webhooks on repo related to Docker Hub

### References

* **GitHub Actions**
  * https://github.com/actions/checkout
  * https://github.com/actions/create-release
  * https://github.com/docker/setup-qemu-action
  * https://github.com/docker/setup-buildx-action
  * https://github.com/docker/login-action
  * https://github.com/docker/build-push-action
  * https://github.com/docker/metadata-action
  * https://github.com/peter-evans/dockerhub-description
* **Docker Hub**
  * https://docs.docker.com/build/ci/github-actions/test-before-push/
  * https://docs.docker.com/build/ci/github-actions/multi-platform/
  * https://docs.docker.com/build/ci/github-actions/secrets/
  * https://docs.docker.com/build/ci/github-actions/manage-tags-labels/
  * https://docs.docker.com/build/ci/github-actions/cache/
  * https://docs.docker.com/build/ci/github-actions/update-dockerhub-desc/