### PR TITLE
[SRE-4808] Upgrade Nginx to v1.27.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.27.4
+
+* Upgrade to Nginx 1.27.4.
+
 ## 1.27.1
 
 * Upgrade to Nginx 1.27.1.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.27.1-bookworm
+FROM nginx:1.27.4-bookworm
 
 ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.7'
 services:
   nginx:
     image: nginx


### PR DESCRIPTION
### Overview

Upgrades Nginx to [v1.27.4](https://github.com/nginx/nginx/releases/tag/release-1.27.4) to side-step the following error when building the [`docker-nginx-proxy`](https://github.com/Intellection/docker-nginx-proxy/) image:

```
nginx: [emerg] module "/etc/nginx/modules/ngx_http_headers_more_filter_module.so" version 1027001 instead of 1027004 in /etc/nginx/nginx.conf:1
```

See [changelog](https://nginx.org/en/CHANGES) for what's changed since v1.27.1.

### References

* https://nginx.org/en/CHANGES
